### PR TITLE
Suggestion/custom web app factory

### DIFF
--- a/src/MinimalAPI/Entities/FileModel.cs
+++ b/src/MinimalAPI/Entities/FileModel.cs
@@ -1,0 +1,11 @@
+namespace MinimalAPI.Entities;
+
+internal record FileModel(IFormFile? File)
+{
+    public static async ValueTask<FileModel?> BindAsync(HttpContext context)
+    {
+        var form = await context.Request.ReadFormAsync();
+        var file = form.Files["file"];
+        return new FileModel(file);
+    }
+}

--- a/src/MinimalAPI/Program.cs
+++ b/src/MinimalAPI/Program.cs
@@ -83,6 +83,8 @@ app.MapPost("/upload", (FileModel model) =>
 
 app.Run();
 
+public partial class Program { }
+
 internal record FileModel(IFormFile? File)
 {
     public static async ValueTask<FileModel?> BindAsync(HttpContext context)

--- a/src/MinimalAPI/Program.cs
+++ b/src/MinimalAPI/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using MinimalAPI;
 using MinimalAPI.Auth;
 using MinimalAPI.DataSource.Tables;
+using MinimalAPI.Entities;
 using MinimalAPI.Extensions;
 using System.Security.Claims;
 
@@ -84,13 +85,3 @@ app.MapPost("/upload", (FileModel model) =>
 app.Run();
 
 public partial class Program { }
-
-internal record FileModel(IFormFile? File)
-{
-    public static async ValueTask<FileModel?> BindAsync(HttpContext context)
-    {
-        var form = await context.Request.ReadFormAsync();
-        var file = form.Files["file"];
-        return new FileModel(file);
-    }
-}

--- a/tests/MinimalAPI.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/MinimalAPI.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using MinimalAPI.DataSource.Tables;
+
+namespace MinimalAPI.IntegrationTests
+{
+    public class CustomWebApplicationFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint> 
+        where TEntryPoint : class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<StoreDbContext>));
+
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddDbContext<StoreDbContext>(options =>
+                {
+                    options.UseInMemoryDatabase("TestInMemory");
+                });
+            });
+        }
+    }
+}

--- a/tests/MinimalAPI.IntegrationTests/MinimalAPI.IntegrationTests.csproj
+++ b/tests/MinimalAPI.IntegrationTests/MinimalAPI.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/tests/MinimalAPI.IntegrationTests/Properties/launchSettings.json
+++ b/tests/MinimalAPI.IntegrationTests/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "MinimalAPI.IntegrationTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:14960;http://localhost:14961"
+    }
+  }
+}

--- a/tests/MinimalAPI.IntegrationTests/ShoppingCartTests.cs
+++ b/tests/MinimalAPI.IntegrationTests/ShoppingCartTests.cs
@@ -1,48 +1,29 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using MinimalAPI.Auth;
+﻿using MinimalAPI.Auth;
 using MinimalAPI.DataSource.Tables;
 using Newtonsoft.Json;
 using System.Text;
 
 namespace MinimalAPI.IntegrationTests
 {
-    public class ShoppingCartTests
+    public class ShoppingCartTests : IClassFixture<CustomWebApplicationFactory<Program>>
     {
+        private readonly HttpClient _client;
+
+        public ShoppingCartTests(CustomWebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
         [Fact]
         public async Task CreateShoppingCartItem_ShouldReturnItemCreated()
         {
-            var appFactory = new WebApplicationFactory<Program>()
-                .WithWebHostBuilder(host =>
-                {
-                    host.ConfigureServices(services =>
-                    {
-                        var descriptor = services.SingleOrDefault(
-                            d => d.ServiceType ==
-                            typeof(DbContextOptions<StoreDbContext>));
-
-                        if (descriptor != null)
-                        {
-                            services.Remove(descriptor);
-                        }
-
-                        services.AddDbContext<StoreDbContext>(options =>
-                        {
-                            options.UseInMemoryDatabase("TestInMemory");
-                        });
-                    });
-                });
-
-            var httpClient = appFactory.CreateClient();
-
             // generate token
-            using var tokenResponse = await httpClient.PostAsync("/login", null);
+            using var tokenResponse = await _client.PostAsync("/login", null);
             Assert.True(tokenResponse.IsSuccessStatusCode);
             var tokenStringResponse = await tokenResponse.Content.ReadAsStringAsync();
             Assert.False(string.IsNullOrWhiteSpace(tokenStringResponse));
             var token = JsonConvert.DeserializeObject<Token>(tokenStringResponse);
-            httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token!.AccessToken}");
+            _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token!.AccessToken}");
 
             // create shopping cart item
             ShoppingCartItem shoppingItem = new()
@@ -51,14 +32,14 @@ namespace MinimalAPI.IntegrationTests
                 ItemName = "Test item",
                 Quantity = 1
             };
-            using var createResponse = await httpClient.PostAsync("/shoppingcart", new StringContent(JsonConvert.SerializeObject(shoppingItem), Encoding.UTF8, "application/json"));
+            using var createResponse = await _client.PostAsync("/shoppingcart", new StringContent(JsonConvert.SerializeObject(shoppingItem), Encoding.UTF8, "application/json"));
             Assert.True(createResponse.IsSuccessStatusCode);
             var createStringResponse = await createResponse.Content.ReadAsStringAsync();
             Assert.False(string.IsNullOrWhiteSpace(createStringResponse));
             var createdShoppingCartItem = JsonConvert.DeserializeObject<ShoppingCartItem>(createStringResponse);
 
             // get shopping cart item created
-            using var response = await httpClient.GetAsync($"/shoppingcart/{createdShoppingCartItem!.Id}");
+            using var response = await _client.GetAsync($"/shoppingcart/{createdShoppingCartItem!.Id}");
             Assert.True(response.IsSuccessStatusCode);
             var getStringResponse = await response.Content.ReadAsStringAsync();
             Assert.False(string.IsNullOrWhiteSpace(getStringResponse));

--- a/tests/MinimalAPI.IntegrationTests/xunit.runner.json
+++ b/tests/MinimalAPI.IntegrationTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+	"shadowCopy": false
+}


### PR DESCRIPTION
in-memory test is cleaned up by:
1. CustomWebApplicationFactory introduction
2. http client extension methods utilization
3. web sdk is used in test instead of plain sdk (a best practice for such tests)